### PR TITLE
fix: use secret storage

### DIFF
--- a/src/services/spotify/spotify-manager.test.ts
+++ b/src/services/spotify/spotify-manager.test.ts
@@ -1,4 +1,3 @@
-import { createMockApp } from "test/fixtures/app";
 import { createMockPlugin } from "test/fixtures/plugin";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -60,8 +59,18 @@ describe("spotify-manager", () => {
   describe(clearCachedService, () => {
     it("should clear the cached service", () => {
       const plugin = createMockPlugin({
-        spotifyClientId: "test-client-id",
-        spotifyClientSecret: "test-client-secret",
+        secretStorage: {
+          getSecret: (key: string) => {
+            if (key === "spotify-client-id") {
+              return "test-client-id";
+            }
+            if (key === "spotify-client-secret") {
+              return "test-client-secret";
+            }
+
+            return null;
+          },
+        },
       });
 
       const service1 = getOrCreateSpotifyService(plugin);
@@ -81,9 +90,7 @@ describe("spotify-manager", () => {
     it("should return null when client ID is missing", () => {
       const plugin = createMockPlugin({
         spotifyClientId: "",
-        spotifyClientSecret: "test-secret",
       });
-      plugin.app = createMockApp() as unknown as typeof plugin.app;
 
       const result = getOrCreateSpotifyService(plugin);
 
@@ -92,10 +99,8 @@ describe("spotify-manager", () => {
 
     it("should return null when client secret is missing", () => {
       const plugin = createMockPlugin({
-        spotifyClientId: "test-id",
         spotifyClientSecret: "",
       });
-      plugin.app = createMockApp() as unknown as typeof plugin.app;
 
       const result = getOrCreateSpotifyService(plugin);
 
@@ -107,21 +112,27 @@ describe("spotify-manager", () => {
         spotifyClientId: "",
         spotifyClientSecret: "",
       });
-      const mockApp = createMockApp();
-      plugin.app = mockApp as unknown as typeof plugin.app;
 
       getOrCreateSpotifyService(plugin);
 
-      expect(mockApp.setting.open).toHaveBeenCalledWith();
-      expect(mockApp.setting.openTabById).toHaveBeenCalledWith(
-        "obsidian-song-of-the-day",
-      );
+      expect(plugin.app.secretStorage.getSecret).toHaveBeenCalledWith("");
+      expect(plugin.app.secretStorage.getSecret).toHaveBeenCalledTimes(2);
     });
 
     it("should create a new SpotifyService when credentials are valid", () => {
       const plugin = createMockPlugin({
-        spotifyClientId: "test-client-id",
-        spotifyClientSecret: "test-client-secret",
+        secretStorage: {
+          getSecret: (key: string) => {
+            if (key === "spotify-client-id") {
+              return "test-client-id";
+            }
+            if (key === "spotify-client-secret") {
+              return "test-client-secret";
+            }
+
+            return null;
+          },
+        },
       });
 
       const result = getOrCreateSpotifyService(plugin);
@@ -135,8 +146,18 @@ describe("spotify-manager", () => {
 
     it("should return cached service on subsequent calls with same credentials", () => {
       const plugin = createMockPlugin({
-        spotifyClientId: "test-client-id",
-        spotifyClientSecret: "test-client-secret",
+        secretStorage: {
+          getSecret: (key: string) => {
+            if (key === "spotify-client-id") {
+              return "test-client-id";
+            }
+            if (key === "spotify-client-secret") {
+              return "test-client-secret";
+            }
+
+            return null;
+          },
+        },
       });
 
       const service1 = getOrCreateSpotifyService(plugin);
@@ -148,14 +169,35 @@ describe("spotify-manager", () => {
 
     it("should create new service when credentials change", () => {
       const plugin = createMockPlugin({
-        spotifyClientId: "test-client-id-1",
-        spotifyClientSecret: "test-client-secret-1",
+        secretStorage: {
+          getSecret: (key: string) => {
+            if (key === "spotify-client-id") {
+              return "test-client-id";
+            }
+            if (key === "spotify-client-secret") {
+              return "test-client-secret";
+            }
+
+            return null;
+          },
+        },
       });
 
       getOrCreateSpotifyService(plugin);
 
-      plugin.settings.spotifyClientId = "test-client-id-2";
-      plugin.settings.spotifyClientSecret = "test-client-secret-2";
+      // Update the mock secret storage to return new credentials
+      vi.spyOn(plugin.app.secretStorage, "getSecret").mockImplementation(
+        (key: string) => {
+          if (key === "spotify-client-id") {
+            return "test-client-id-2";
+          }
+          if (key === "spotify-client-secret") {
+            return "test-client-secret-2";
+          }
+
+          return null;
+        },
+      );
 
       getOrCreateSpotifyService(plugin);
 
@@ -168,9 +210,19 @@ describe("spotify-manager", () => {
 
     it("should initialize user API when OAuth tokens are present", () => {
       const plugin = createMockPlugin({
+        secretStorage: {
+          getSecret: (key: string) => {
+            if (key === "spotify-client-id") {
+              return "test-client-id";
+            }
+            if (key === "spotify-client-secret") {
+              return "test-client-secret";
+            }
+
+            return null;
+          },
+        },
         spotifyAccessToken: "test-access-token",
-        spotifyClientId: "test-client-id",
-        spotifyClientSecret: "test-client-secret",
         spotifyRefreshToken: "test-refresh-token",
         spotifyTokenExpiry: Date.now() + 3_600_000,
       });
@@ -187,8 +239,18 @@ describe("spotify-manager", () => {
 
     it("should not initialize user API when OAuth tokens are missing", () => {
       const plugin = createMockPlugin({
-        spotifyClientId: "test-client-id",
-        spotifyClientSecret: "test-client-secret",
+        secretStorage: {
+          getSecret: (key: string) => {
+            if (key === "spotify-client-id") {
+              return "test-client-id";
+            }
+            if (key === "spotify-client-secret") {
+              return "test-client-secret";
+            }
+
+            return null;
+          },
+        },
       });
 
       getOrCreateSpotifyService(plugin);
@@ -199,9 +261,19 @@ describe("spotify-manager", () => {
     it("should update plugin settings when tokens are refreshed", async () => {
       setupTokenCallbackCapture();
       const plugin = createMockPlugin({
+        secretStorage: {
+          getSecret: (key: string) => {
+            if (key === "spotify-client-id") {
+              return "test-client-id";
+            }
+            if (key === "spotify-client-secret") {
+              return "test-client-secret";
+            }
+
+            return null;
+          },
+        },
         spotifyAccessToken: "old-access-token",
-        spotifyClientId: "test-client-id",
-        spotifyClientSecret: "test-client-secret",
         spotifyRefreshToken: "old-refresh-token",
         spotifyTokenExpiry: Date.now() + 3_600_000,
       });
@@ -224,9 +296,19 @@ describe("spotify-manager", () => {
     it("should show notice when saving tokens fails", async () => {
       setupTokenCallbackCapture();
       const plugin = createMockPlugin({
+        secretStorage: {
+          getSecret: (key: string) => {
+            if (key === "spotify-client-id") {
+              return "test-client-id";
+            }
+            if (key === "spotify-client-secret") {
+              return "test-client-secret";
+            }
+
+            return null;
+          },
+        },
         spotifyAccessToken: "old-access-token",
-        spotifyClientId: "test-client-id",
-        spotifyClientSecret: "test-client-secret",
         spotifyRefreshToken: "old-refresh-token",
         spotifyTokenExpiry: Date.now() + 3_600_000,
       });
@@ -257,9 +339,19 @@ describe("spotify-manager", () => {
     it("should handle non-Error rejection when saving tokens fails", async () => {
       setupTokenCallbackCapture();
       const plugin = createMockPlugin({
+        secretStorage: {
+          getSecret: (key: string) => {
+            if (key === "spotify-client-id") {
+              return "test-client-id";
+            }
+            if (key === "spotify-client-secret") {
+              return "test-client-secret";
+            }
+
+            return null;
+          },
+        },
         spotifyAccessToken: "old-access-token",
-        spotifyClientId: "test-client-id",
-        spotifyClientSecret: "test-client-secret",
         spotifyRefreshToken: "old-refresh-token",
         spotifyTokenExpiry: Date.now() + 3_600_000,
       });

--- a/src/services/spotify/spotify-manager.ts
+++ b/src/services/spotify/spotify-manager.ts
@@ -1,6 +1,7 @@
 import type SongOfTheDayPlugin from "main";
 
 import { Notice } from "obsidian";
+import { getClientId, getClientSecret } from "src/utils/secret-storage";
 
 import pkg from "../../../package.json";
 import { SpotifyService } from "../spotify";
@@ -33,10 +34,10 @@ export function clearCachedService(): void {
 export function getOrCreateSpotifyService(
   plugin: SongOfTheDayPlugin,
 ): null | SpotifyService {
-  if (
-    !plugin.settings.spotifyClientId ||
-    !plugin.settings.spotifyClientSecret
-  ) {
+  const clientId = getClientId(plugin);
+  const clientSecret = getClientSecret(plugin);
+
+  if (!clientId || !clientSecret) {
     new Notice("Configure Spotify API credentials in settings");
     plugin.app.setting.open();
     plugin.app.setting.openTabById(pkg.name);
@@ -46,21 +47,18 @@ export function getOrCreateSpotifyService(
 
   if (
     cachedService &&
-    storedCredentials?.clientId === plugin.settings.spotifyClientId &&
-    storedCredentials.clientSecret === plugin.settings.spotifyClientSecret
+    storedCredentials?.clientId === clientId &&
+    storedCredentials.clientSecret === clientSecret
   ) {
     return cachedService;
   }
 
   storedCredentials = {
-    clientId: plugin.settings.spotifyClientId,
-    clientSecret: plugin.settings.spotifyClientSecret,
+    clientId,
+    clientSecret,
   };
 
-  const service = new SpotifyService(
-    plugin.settings.spotifyClientId,
-    plugin.settings.spotifyClientSecret,
-  );
+  const service = new SpotifyService(clientId, clientSecret);
 
   if (
     plugin.settings.spotifyAccessToken &&

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -15,11 +15,11 @@ export const NOTE_NAME_CASING = {
   SNAKE_CASE: "snake_case",
 } as const;
 
-export const SPOTIFY_API_DOCS_URL
-  = "https://developer.spotify.com/documentation/web-api/concepts/apps";
+export const SPOTIFY_API_DOCS_URL =
+  "https://developer.spotify.com/documentation/web-api/concepts/apps";
 
-export const MOMENT_FORMAT_DOCS_URL
-  = "https://momentjs.com/docs/#/displaying/format/";
+export const MOMENT_FORMAT_DOCS_URL =
+  "https://momentjs.com/docs/#/displaying/format/";
 
 /**
  * Generates default frontmatter fields from the field registry.
@@ -43,9 +43,9 @@ export const DEFAULT_SETTINGS: SongOfTheDaySettings = {
   noteTemplate: "# {{title}}\n\n",
   outputFolder: "",
   playlistId: "",
-  spotifyAccessToken: "",
-  spotifyClientId: "",
-  spotifyClientSecret: "",
-  spotifyRefreshToken: "",
+  spotifyAccessToken: "spotify-access-token",
+  spotifyClientId: "spotify-client-id",
+  spotifyClientSecret: "spotify-client-secret",
+  spotifyRefreshToken: "spotify-refresh-token",
   spotifyTokenExpiry: 0,
 };

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -537,8 +537,8 @@ export class SongOfTheDaySettingTab extends PluginSettingTab {
    */
   private updateCredentialsHelpEl(): void {
     if (
-      this.plugin.settings.spotifyClientId &&
-      this.plugin.settings.spotifyClientSecret &&
+      getClientId(this.plugin) &&
+      getClientSecret(this.plugin) &&
       this.credentialsHelpEl
     ) {
       this.credentialsHelpEl.remove();

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -18,6 +18,7 @@ import {
   getNoteNameCasingLabel,
   getNoteNameStructureLabel,
 } from "src/utils/format";
+import { getClientId, getClientSecret } from "src/utils/secret-storage";
 
 import {
   DEFAULT_SETTINGS,
@@ -71,10 +72,7 @@ export class SongOfTheDaySettingTab extends PluginSettingTab {
    * @param containerEl The container element to add the help text to
    */
   private createApiCredentialsHelp(containerEl: HTMLElement): void {
-    if (
-      this.plugin.settings.spotifyClientId &&
-      this.plugin.settings.spotifyClientSecret
-    ) {
+    if (getClientId(this.plugin) && getClientSecret(this.plugin)) {
       return;
     }
 
@@ -376,16 +374,12 @@ export class SongOfTheDaySettingTab extends PluginSettingTab {
         return new SecretComponent(this.app, el)
           .setValue(this.plugin.settings.spotifyClientId)
           .onChange(async (value) => {
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- value may null
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- value is null if user clears the input
             const trimmedValue = value?.trim();
             this.plugin.settings.spotifyClientId = trimmedValue;
             await this.plugin.saveSettings();
 
-            if (
-              !this.app.secretStorage.getSecret(
-                this.plugin.settings.spotifyClientId,
-              )
-            ) {
+            if (!trimmedValue) {
               errorEl ??= this.createErrorElement(
                 setting.infoEl,
                 "Client ID is required to use this plugin",
@@ -401,9 +395,7 @@ export class SongOfTheDaySettingTab extends PluginSettingTab {
           });
       });
 
-    if (
-      !this.app.secretStorage.getSecret(this.plugin.settings.spotifyClientId)
-    ) {
+    if (!getClientId(this.plugin)) {
       errorEl = this.createErrorElement(
         setting.infoEl,
         "Client ID is required to use this plugin",
@@ -416,6 +408,7 @@ export class SongOfTheDaySettingTab extends PluginSettingTab {
    * @param containerEl The container element to add the setting to
    */
   private createSpotifyClientSecretSetting(containerEl: HTMLElement): void {
+    let errorEl: HTMLElement | null = null;
     const setting = new Setting(containerEl)
       .setName("Spotify client secret")
       .setDesc("Spotify application client secret.")
@@ -423,16 +416,12 @@ export class SongOfTheDaySettingTab extends PluginSettingTab {
         return new SecretComponent(this.app, el)
           .setValue(this.plugin.settings.spotifyClientSecret)
           .onChange(async (value) => {
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- value may be null
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- value is null if user clears the input
             const trimmedValue = value?.trim();
             this.plugin.settings.spotifyClientSecret = trimmedValue;
             await this.plugin.saveSettings();
 
-            if (
-              !this.app.secretStorage.getSecret(
-                this.plugin.settings.spotifyClientSecret,
-              )
-            ) {
+            if (!trimmedValue) {
               errorEl ??= this.createErrorElement(
                 setting.infoEl,
                 "Client Secret is required to use this plugin",
@@ -448,7 +437,12 @@ export class SongOfTheDaySettingTab extends PluginSettingTab {
           });
       });
 
-    let errorEl: HTMLElement | null = null;
+    if (!getClientSecret(this.plugin)) {
+      errorEl = this.createErrorElement(
+        setting.infoEl,
+        "Client Secret is required to use this plugin",
+      );
+    }
   }
 
   /**

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -11,11 +11,11 @@ export type FrontmatterFields = Record<
   boolean
 >;
 
-export type NoteNameCasing
-  = (typeof NOTE_NAME_CASING)[keyof typeof NOTE_NAME_CASING];
+export type NoteNameCasing =
+  (typeof NOTE_NAME_CASING)[keyof typeof NOTE_NAME_CASING];
 
-export type NoteNameStructure
-  = (typeof NOTE_NAME_STRUCTURE)[keyof typeof NOTE_NAME_STRUCTURE];
+export type NoteNameStructure =
+  (typeof NOTE_NAME_STRUCTURE)[keyof typeof NOTE_NAME_STRUCTURE];
 
 export interface SongOfTheDaySettings {
   addedTrackIds: string[];
@@ -27,7 +27,17 @@ export interface SongOfTheDaySettings {
   outputFolder: string;
   playlistId: string;
   spotifyAccessToken: string;
+
+  /**
+   * Spotify Client Id is stored in Obsidian's secret storage for security.
+   * spotifyClientId holds the key to retrieve it, not the ID itself.
+   */
   spotifyClientId: string;
+
+  /**
+   * Spotify Client Secret is stored in Obsidian's secret storage for security.
+   * spotifyClientSecret holds the key to retrieve it, not the secret itself.
+   */
   spotifyClientSecret: string;
   spotifyRefreshToken: string;
   spotifyTokenExpiry: number;

--- a/src/utils/secret-storage.ts
+++ b/src/utils/secret-storage.ts
@@ -1,0 +1,21 @@
+import SongOfTheDayPlugin from "main";
+
+/**
+ * Retrieves the Spotify Client Id from Obsidian's secret storage.
+ * @param plugin The plugin instance to access Obsidian's secret storage and settings
+ * @returns The Spotify Client Id from Obsidian's secret storage, or null if not set
+ */
+export function getClientId(plugin: SongOfTheDayPlugin): null | string {
+  return plugin.app.secretStorage.getSecret(plugin.settings.spotifyClientId);
+}
+
+/**
+ * Retrieves the Spotify Client Secret from Obsidian's secret storage.
+ * @param plugin The plugin instance to access Obsidian's secret storage and settings
+ * @returns The Spotify Client Secret from Obsidian's secret storage, or null if not set
+ */
+export function getClientSecret(plugin: SongOfTheDayPlugin): null | string {
+  return plugin.app.secretStorage.getSecret(
+    plugin.settings.spotifyClientSecret,
+  );
+}

--- a/test/fixtures/app.ts
+++ b/test/fixtures/app.ts
@@ -10,6 +10,10 @@ export interface MockApp {
   fileManager: {
     processFrontMatter: ReturnType<typeof vi.fn>;
   };
+  secretStorage: {
+    getSecret: ReturnType<typeof vi.fn>;
+    setSecret: ReturnType<typeof vi.fn>;
+  };
   setting: {
     open: ReturnType<typeof vi.fn>;
     openTabById: ReturnType<typeof vi.fn>;
@@ -60,6 +64,10 @@ export function createMockApp(options: MockAppOptions = {}): MockApp {
   return {
     fileManager: {
       processFrontMatter: vi.fn().mockResolvedValue(undefined),
+    },
+    secretStorage: {
+      getSecret: vi.fn<(key: string) => string | null>().mockReturnValue(null),
+      setSecret: vi.fn<(key: string, value: string) => void>().mockImplementation(() => undefined),
     },
     setting: {
       open: vi.fn<() => void>(),

--- a/test/fixtures/plugin.ts
+++ b/test/fixtures/plugin.ts
@@ -2,11 +2,17 @@ import SongOfTheDayPlugin from "main";
 import { App } from "obsidian";
 import { DEFAULT_SETTINGS } from "src/settings/constants";
 import { SongOfTheDaySettings } from "src/settings/types";
+import { vi } from "vitest";
 
 /**
  * Options for customizing the mock plugin.
  */
-export type MockPluginOptions = Partial<SongOfTheDaySettings>;
+export type MockPluginOptions = Partial<SongOfTheDaySettings> & {
+  secretStorage?: {
+    getSecret?: (key: string) => string | null;
+    setSecret?: (key: string, value: string) => void;
+  };
+};
 
 /**
  * Creates a mock plugin instance for testing.
@@ -15,11 +21,29 @@ export type MockPluginOptions = Partial<SongOfTheDaySettings>;
 export function createMockPlugin(
   options: MockPluginOptions = {},
 ): SongOfTheDayPlugin {
+  const { secretStorage, ...settingsOptions } = options;
+
+  // Create a mock app with secretStorage and setting
+  const mockApp = {
+    secretStorage: {
+      getSecret: vi.fn<(key: string) => string | null>().mockImplementation(
+        (key: string) => secretStorage?.getSecret?.(key) ?? null,
+      ),
+      setSecret: vi.fn<(key: string, value: string) => void>().mockImplementation(
+        (key: string, value: string) => secretStorage?.setSecret?.(key, value),
+      ),
+    },
+    setting: {
+      open: vi.fn<() => void>(),
+      openTabById: vi.fn<(id: string) => void>(),
+    },
+  };
+
   return {
     addCommand: () => undefined,
-    app: new App(),
+    app: mockApp,
     getSpotifyService: () => null,
     saveSettings: async () => undefined,
-    settings: { ...DEFAULT_SETTINGS, ...options },
+    settings: { ...DEFAULT_SETTINGS, ...settingsOptions },
   } as unknown as SongOfTheDayPlugin;
 }


### PR DESCRIPTION
a36dca5698b8 updated settings to use [SecretStorage](https://docs.obsidian.md/plugins/guides/secret-storage)

this pr fixes access stored secrets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated Spotify credential storage to use Obsidian's secure secret storage system.
  * Added utility functions for credential access throughout the application.

* **Settings**
  * Updated credential validation logic to work with the new storage mechanism.
  * Modified default credential placeholder values.

* **Tests**
  * Updated test suite to verify functionality with secure secret storage.
  * Enhanced mock fixtures to support secret storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->